### PR TITLE
Create Champion in focus screen

### DIFF
--- a/src/championOverview/ChampionOverview.tsx
+++ b/src/championOverview/ChampionOverview.tsx
@@ -5,50 +5,6 @@ import { useNavigate } from "react-router-dom";
 import { SortableTable } from "../components/SortableTable";
 import { statsSelector } from "../redux/statsSelectors";
 import { Champion } from "../types/domain/Champion";
-import { Player } from "../types/domain/Player";
-
-/**
- * Given a collection of players, map to a key value pair of championName to champion that has stats centered around that champion
- * @param data
- */
-const processChampions = (
-  data: Player[] | undefined
-): {
-  [key: string]: Champion;
-} => {
-  const championMap: { [key: string]: Champion } = {};
-  if (data) {
-    for (const player of data) {
-      // iterate through the player's champions to aggregate champion info
-      if (player.champions) {
-        for (const [key, value] of Object.entries(player.champions)) {
-          if (championMap[key] === undefined) {
-            // champion does not exist in our collection, so we can add it
-            championMap[key] = {
-              name: key,
-              losses: value.losses,
-              wins: value.wins,
-              totalGames: value.losses + value.wins,
-              winPercentage: value.winPercentage,
-            };
-          } else {
-            const wins = championMap[key].wins + value.wins;
-            const losses = championMap[key].losses + value.losses;
-            championMap[key] = {
-              name: key,
-              losses,
-              wins,
-              winPercentage: Math.round((wins / (wins + losses)) * 100),
-              totalGames:
-                championMap[key].totalGames + value.losses + value.wins,
-            };
-          }
-        }
-      }
-    }
-  }
-  return championMap;
-};
 
 const columnHelper = createColumnHelper<Champion>();
 
@@ -94,10 +50,9 @@ const columns: ColumnDef<Champion, any>[] = [
 
 export const ChampionOverview = React.memo(function ChampionOverview() {
   const navigate = useNavigate();
-  const data = useSelector(statsSelector.getPlayers);
-  const processedChampionMap = processChampions(data);
+  const data = useSelector(statsSelector.getChampionsCollection);
   const processedChampionArray = Array.from(
-    Object.values(processedChampionMap)
+    Object.values(data ?? [])
   );
 
   return (

--- a/src/championOverview/ChampionScreen.tsx
+++ b/src/championOverview/ChampionScreen.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { useSelector } from "react-redux";
+import { useLoaderData } from "react-router-dom";
+import { AppState } from "../redux/rootReducer";
+import { statsSelector } from "../redux/statsSelectors";
+
+export async function loader(data: {params: any}) {
+    return data.params.championId;
+}
+
+export const ChampionScreen = React.memo(function ChampionScreen() {
+    const championId = useLoaderData() as string;
+    const champion = useSelector((state: AppState) => statsSelector.getChampion(state, championId ?? ""));
+
+    if (champion === undefined) {
+        return <div style={
+            {display: "flex",
+            minHeight: "100vh",
+            backgroundColor: "#282c34",
+            justifyContent: "center",
+            alignItems: "center"}
+        }>
+            <h1 style={{color: "white"}}>Champion not found</h1>
+        </div>
+    }
+
+    return <div style={{display: "flex", flexDirection: "column", justifyContent: "center", alignItems: "center"}}>
+        <div style={{marginBottom: 32}}>
+            <h1>{champion.name}</h1>
+            <h1>{"Wins: " + champion.wins}</h1>
+            <h1>{"Losses: " + champion.losses}</h1>
+            <h1>{"Win Percentage: " + champion.winPercentage + "%"}</h1>
+            <h1>{"Total Games: " + champion.totalGames}</h1>
+        </div>
+    </div>;
+});

--- a/src/home/Home.tsx
+++ b/src/home/Home.tsx
@@ -4,6 +4,7 @@ import { useDispatch } from "react-redux";
 import { StatsAction } from "../redux/statsActions";
 import { mapStats } from "../services/dataMapper";
 import { fetchMMR, fetchStats } from "../services/dataService";
+import { Champion } from "../types/domain/Champion";
 import { Player } from "../types/domain/Player";
 import { MmrData } from "../types/service/MmrData";
 import { StatsData } from "../types/service/StatsData";
@@ -11,7 +12,7 @@ import { StatsData } from "../types/service/StatsData";
 export default function Home() {
     const dispatch = useDispatch();
 
-    const statsResponse = useQuery<StatsData, Error, Player[]>(
+    const statsResponse = useQuery<StatsData, Error, {players: Player[], champions: {[id: string]: Champion}}>(
         ["stats"],
         fetchStats,
         {
@@ -40,7 +41,8 @@ export default function Home() {
 
     useEffect(()=>{
         if (!statsResponse.isLoading && statsResponse.data !== undefined) {
-            dispatch(StatsAction.hydratePlayerStatsActionComplete(statsResponse.data));
+            dispatch(StatsAction.hydratePlayerStatsActionComplete(statsResponse.data.players));
+            dispatch(StatsAction.hydrateChampionStatsActionComplete(statsResponse.data.champions));
         }
     },[statsResponse.isLoading, statsResponse.data]);
 

--- a/src/navigation/routes.tsx
+++ b/src/navigation/routes.tsx
@@ -4,11 +4,9 @@ import { PlayerOverview } from "../playerOverview/PlayerOverview";
 import Home from "../home/Home";
 import { Matchmaker } from "../matchmaker/Matchmaker";
 import Root from "./Root";
-import {
-  loader as playerLoader,
-  PlayerScreen,
-} from "../playerOverview/PlayerScreen";
-import { ChampionOverview } from "../championOverview/ChampionOverview";
+import { loader as playerLoader, PlayerScreen } from '../playerOverview/PlayerScreen';
+import { ChampionOverview } from '../championOverview/ChampionOverview';
+import { loader as championLoader, ChampionScreen } from '../championOverview/ChampionScreen';
 
 export const router = createBrowserRouter([
   {
@@ -37,6 +35,11 @@ export const router = createBrowserRouter([
         path: "/championOverview",
         element: <ChampionOverview />,
       },
-    ],
+      {
+        path: "/championOverview/:championId",
+        loader: championLoader,
+        element: <ChampionScreen/>,
+      },
+    ]
   },
 ]);

--- a/src/playerOverview/PlayerOverview.tsx
+++ b/src/playerOverview/PlayerOverview.tsx
@@ -91,7 +91,7 @@ const columns: ColumnDef<PlayerTableData, any>[] = [
 
 export const PlayerOverview = React.memo(function PlayerOverview() {
   const navigate = useNavigate();
-  const data = useSelector(statsSelector.getPlayers);
+  const data = useSelector(statsSelector.getPlayersCollection);
   const processedData = processPlayers(data);
 
   return (

--- a/src/redux/statsActions.ts
+++ b/src/redux/statsActions.ts
@@ -1,9 +1,11 @@
 import {createAction} from "@reduxjs/toolkit";
+import { Champion } from "../types/domain/Champion";
 import { Player } from "../types/domain/Player";
 
 export enum StatsActionType {
     HydratePlayerStatsComplete = "PlayerStatsActions/HydratePlayerStatsComplete",
     HydratePlayerMmrComplete = "PlayerStatsActions/HydratePlayerMmrComplete",
+    HydrateChampionStatsComplete = "PlayerStatsActions/HydrateChampionStatsComplete",
 }
 
 export const StatsAction = {
@@ -14,5 +16,9 @@ export const StatsAction = {
     hydratePlayerMmrComplete: createAction(StatsActionType.HydratePlayerMmrComplete, (data: Player[]) => ({
         type: StatsActionType.HydratePlayerMmrComplete, 
         payload: data
-    }))
+    })),
+    hydrateChampionStatsActionComplete: createAction(StatsActionType.HydrateChampionStatsComplete, (data: {[id: string]: Champion}) => ({
+        type: StatsActionType.HydrateChampionStatsComplete, 
+        payload: data
+    })),
 };

--- a/src/redux/statsReducer.ts
+++ b/src/redux/statsReducer.ts
@@ -2,15 +2,20 @@ import { Player } from '../types/domain/Player';
 import { StatsAction } from './statsActions';
 
 import { createReducer } from '@reduxjs/toolkit'
+import { Champion } from '../types/domain/Champion';
 
 export type StatsState = Readonly<{
     players:{
       [id: string]: Player;
     } | undefined;
+    champions: {
+      [id: string]: Champion;
+    } | undefined;
   }>;
   
 const initialState: StatsState = {
-  players: undefined
+  players: undefined,
+  champions: undefined
 };
 
 export const statsReducer = createReducer(initialState, (builder) => {
@@ -54,6 +59,17 @@ export const statsReducer = createReducer(initialState, (builder) => {
       } else {
         state.players[player.name] = {name: player.name, mmr: player.mmr };
       }
+    }
+  })
+  .addCase(StatsAction.hydrateChampionStatsActionComplete, (state, action) => {
+    const championsMap = action.payload;
+
+    if (state.champions === undefined) {
+      state.champions = {};
+    }
+
+    if (championsMap) {
+      state.champions = action.payload;
     }
   })
 });

--- a/src/redux/statsSelectors.ts
+++ b/src/redux/statsSelectors.ts
@@ -1,23 +1,40 @@
 import { createSelector } from "reselect";
+import { Champion } from "../types/domain/Champion";
 import { Player } from "../types/domain/Player";
 import { AppState } from "./rootReducer";
 
 export const getPlayers = (state: AppState) => state.stats.players;
+export const getChampions = (state: AppState) => state.stats.champions;
 
 export type StatsSelectors<State> = Readonly<{
-  getPlayers: (state: State) => Player[] | undefined;
-  getPlayer: (state: State, playerId: string) => Player | undefined;
+    getPlayersCollection: (state: State) => Player[] | undefined;
+    getPlayer: (state: State, playerId: string) => Player | undefined;
+    getChampionsCollection: (state: State) => Champion[] | undefined;
+    getChampion: (state: State, championId: string) => Champion | undefined;
 }>;
 
 export const statsSelector: StatsSelectors<AppState> = {
-  getPlayers: createSelector(getPlayers, (players) => {
-    return players ? Array.from(Object.values(players)) : undefined;
-  }),
-  getPlayer: createSelector(
-    getPlayers,
-    (state: AppState, playerId: string) => playerId,
-    (players, playerId) => {
-      return players ? players[playerId] : undefined;
-    }
-  ),
+    getPlayersCollection: createSelector(
+        getPlayers,
+        (players) => {
+        return players ? Array.from(Object.values(players)) : undefined;
+    }),
+    getPlayer: createSelector(
+        getPlayers,
+        (state: AppState, playerId: string) => playerId,
+        (players, playerId) => {
+        return players ? players[playerId] : undefined;
+    }),
+    getChampionsCollection: createSelector(
+        getChampions, 
+        (champions) =>  {
+        return champions ? Array.from(Object.values(champions)) : undefined;
+    }),
+    getChampion: createSelector(
+        getChampions,
+        (state: AppState, championId: string) => championId,
+        (champions, championId) => {
+            return champions ? champions[championId] : undefined;
+        }
+    ),
 };

--- a/src/services/dataMapper.ts
+++ b/src/services/dataMapper.ts
@@ -1,7 +1,9 @@
+import { Champion } from "../types/domain/Champion";
 import { Player, PlayerChampionData } from "../types/domain/Player";
 import { StatsData } from "../types/service/StatsData";
 
-export function mapStats(data: StatsData): Player[] {
+export function mapStats(data: StatsData): {players: Player[], champions: {[id: string]: Champion}} {
+    const championMap: { [key: string]: Champion } = {};
     const players: Player[] = Object.entries(data).map(
         (kvPair)=> {
             let wins = 0; 
@@ -19,6 +21,29 @@ export function mapStats(data: StatsData): Player[] {
                     totalGames: champion.loss + champion.win,
                     winPercentage: Math.round(champion.win_rate * 100)
                 }
+
+                // also update our champion map
+                if (championMap[championName] === undefined) {
+                    // champion does not exist in our map, so we can add it
+                    championMap[championName] = {
+                      name: championName,
+                      losses: champion.loss,
+                      wins: champion.win,
+                      totalGames: champion.loss + champion.win,
+                      winPercentage: champion.win_rate,
+                    };
+                  } else {
+                    const wins = championMap[championName].wins + champion.win;
+                    const losses = championMap[championName].losses + champion.loss;
+                    championMap[championName] = {
+                      name: championName,
+                      losses,
+                      wins,
+                      winPercentage: Math.round((wins / (wins + losses)) * 100),
+                      totalGames:
+                        championMap[championName].totalGames + champion.loss + champion.win,
+                    };
+                  }
             }
 
             return {
@@ -30,5 +55,5 @@ export function mapStats(data: StatsData): Player[] {
         }
     )
 
-    return players;
+    return {players, champions: championMap};
 }


### PR DESCRIPTION
This creates the champion in focus screen, adding it to our routes.

Notably, this adds the "champions" map to the StatsState, which is a champId to champion mapping. 

Since champions are now part of the app state and no longer specific to just the championOverview screen, remove the process champions method from ChampionOverview and instead, move that into mapStats. Now mapStats takes a single playerStats response object and returns both an array of players AND a map of champion data. 