### PR TITLE
Add in player MMR history

### DIFF
--- a/src/admin/Slideshow.tsx
+++ b/src/admin/Slideshow.tsx
@@ -125,14 +125,14 @@ export const Slideshow = React.memo(function Slideshow({
     // sort the players by MMR
     const sortedPlayers = players
         ? players
-              .filter((value) => (value.wins ?? 0) + (value.losses ?? 0) > 10)
+              .filter((value) => (value.wins ?? 0) + (value.losses ?? 0) >= 10)
               .sort((a, b) => (b.mmr ?? 0) - (a.mmr ?? 0))
         : [];
 
     // sort the champions by win rate
     const sortedChampions = champions
         ? champions
-              .filter((value) => value.totalGames > 10)
+              .filter((value) => value.totalGames >= 10)
               .sort((a, b) => b.winPercentage - a.winPercentage)
         : [];
 

--- a/src/components/MmrCard.tsx
+++ b/src/components/MmrCard.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { Player } from '../types/domain/Player';
+import { getMmrColor } from '../utils/mmrColorHelpers';
+
+export const MmrCard = React.memo(function MmrCard({
+    player,
+}: {
+    player: Player;
+}) {
+    return (
+        <div
+            style={{
+                display: 'flex',
+                flexDirection: 'column',
+                flex: 1,
+                maxWidth: 150,
+                marginLeft: 32,
+                padding: 16,
+                marginRight: 32,
+                alignItems: 'center',
+            }}
+        >
+            <h1
+                style={
+                    player.mmr
+                        ? {
+                              fontSize: 60,
+                              backgroundColor: getMmrColor(player.mmr),
+                              borderRadius: 10,
+                              paddingLeft: 4,
+                              paddingRight: 4,
+                          }
+                        : {
+                              fontSize: 30,
+                          }
+                }
+            >
+                {player.mmr && (player.wins ?? 0) + (player.losses ?? 0) >= 10
+                    ? Math.round(player.mmr)
+                    : 'Not Placed'}
+            </h1>
+            <h1>{'MMR'}</h1>
+        </div>
+    );
+});

--- a/src/services/toxicData/dataMapper.ts
+++ b/src/services/toxicData/dataMapper.ts
@@ -1,7 +1,9 @@
 import { Champion } from '../../types/domain/Champion';
 import { Match } from '../../types/domain/Match';
+import { MmrHistoryItem } from '../../types/domain/MmrHistoryItem';
 import { Player, PlayerRecord } from '../../types/domain/Player';
 import { MatchData } from '../../types/service/toxicData/MatchData';
+import { MmrPerMatchData } from '../../types/service/toxicData/MmrPerMatchData';
 import { StatsData } from '../../types/service/toxicData/StatsData';
 
 export function mapStats(data: StatsData): {
@@ -216,4 +218,19 @@ export function mapMatchHistory(data: MatchData): Match[] {
         (a, b) => b.date.getTime() - a.date.getTime()
     );
     return sortedHistory;
+}
+
+export function mapMmrPerMatch(data: MmrPerMatchData[]): MmrHistoryItem[] {
+    return data.map((value, index) => {
+        const players: { [key: string]: number } = {};
+
+        for (const [k, v] of Object.entries(value.mmr)) {
+            players[k] = Math.round(v);
+        }
+
+        return {
+            id: index.toString(),
+            players: players,
+        };
+    });
 }

--- a/src/types/domain/MmrHistoryItem.ts
+++ b/src/types/domain/MmrHistoryItem.ts
@@ -1,0 +1,6 @@
+export type MmrHistoryItem = {
+    id: string;
+    players: {
+        [key: string]: number;
+    };
+};

--- a/src/types/service/toxicData/MmrPerMatchData.ts
+++ b/src/types/service/toxicData/MmrPerMatchData.ts
@@ -1,0 +1,5 @@
+export type MmrPerMatchData = {
+    mmr: {
+        [key: string]: number;
+    };
+};


### PR DESCRIPTION
This adds in a new endpoint to the toxic stats service to get player mmr history. also does transformations on this to key it by player, so you can look up the change over time for a specific player's mmr. 