### PR TITLE
Undo the button ts styling because it messes up the match history display

### DIFF
--- a/src/themes/amethyst/components/button.ts
+++ b/src/themes/amethyst/components/button.ts
@@ -3,7 +3,7 @@ import type { ComponentStyleConfig } from '@chakra-ui/theme';
 export const Button: ComponentStyleConfig = {
     defaultProps: {
         variant: 'solid',
-        size: ['sm', 'md', 'lg'],
+        size: ['md'],
         colorScheme: 'primary',
     },
 };


### PR DESCRIPTION
it looks like the button ts styling of ['sm', 'md', 'lg'] breaks the match display in a few ways (the buttons are too small, and the bans disappear)

i tried to play around with it to have specific widths/heights for the buttons, but i think this style was doing some weird things to override it. 

for now, because it affects the usability of the app, i'm undoing the change. We can totally review this one a bit more together later to try to get it back in, but i don't know if it's a deal breaker in any case. 