### PR TITLE
Add responsive button styles and fix MatchDisplay

### DIFF
--- a/src/components/MatchDisplay.tsx
+++ b/src/components/MatchDisplay.tsx
@@ -49,6 +49,7 @@ const MatchPlayerCard = React.memo(
                     onClick={championNav}
                     flex={1}
                     padding={1}
+                    size='md'
                 >
                     <Image src={player.champion.images.portrait} />
                 </Button>
@@ -59,6 +60,7 @@ const MatchPlayerCard = React.memo(
                     backgroundColor={backgroundColor}
                     borderColor={borderColor}
                     borderWidth={borderColor ? 5 : undefined}
+                    size='md'
                 >
                     <Text
                         style={{
@@ -91,6 +93,7 @@ const BannedChampion = React.memo(
                     onClick={championNav}
                     padding={1}
                     flex={1}
+                    size='sm'
                 >
                     <Image
                         src={champion.images.square}

--- a/src/themes/amethyst/components/button.ts
+++ b/src/themes/amethyst/components/button.ts
@@ -3,7 +3,7 @@ import type { ComponentStyleConfig } from '@chakra-ui/theme';
 export const Button: ComponentStyleConfig = {
     defaultProps: {
         variant: 'solid',
-        size: ['md'],
+        size: ['sm', 'md', 'lg'],
         colorScheme: 'primary',
     },
 };


### PR DESCRIPTION
This change should make the button sizes responsive. Buttons that should not resize automatically should have explicit sizes, as with the MatchDisplay buttons.