### PR TITLE
A big set of changes in preparation for genesis

### DIFF
--- a/src/championOverview/ChampionOverview.tsx
+++ b/src/championOverview/ChampionOverview.tsx
@@ -58,7 +58,7 @@ const columns: ColumnDef<ChampionOverviewChampion, any>[] = [
     columnHelper.accessor((row) => row.totalGames, {
         id: 'totalGames',
         cell: (info) => info.getValue(),
-        header: () => <span>Total #</span>,
+        header: () => <span>Total Games</span>,
         meta: {
             isNumeric: true,
         },

--- a/src/championOverview/ChampionOverview.tsx
+++ b/src/championOverview/ChampionOverview.tsx
@@ -42,7 +42,7 @@ const columns: ColumnDef<ChampionOverviewChampion, any>[] = [
     columnHelper.accessor((row) => row.winPercentage, {
         id: 'winPercentage',
         cell: (info) => info.getValue(),
-        header: () => <span>Win Percentage</span>,
+        header: () => <span>Win %</span>,
         meta: {
             isNumeric: true,
         },
@@ -58,7 +58,7 @@ const columns: ColumnDef<ChampionOverviewChampion, any>[] = [
     columnHelper.accessor((row) => row.totalGames, {
         id: 'totalGames',
         cell: (info) => info.getValue(),
-        header: () => <span>Total Games</span>,
+        header: () => <span>Total #</span>,
         meta: {
             isNumeric: true,
         },
@@ -66,7 +66,7 @@ const columns: ColumnDef<ChampionOverviewChampion, any>[] = [
     columnHelper.accessor((row) => row.pickPercentage, {
         id: 'Pick Rate',
         cell: (info) => `${info.getValue()}%`,
-        header: () => <span>Pick Rate</span>,
+        header: () => <span>Pick %</span>,
         meta: {
             isNumeric: true,
         },
@@ -74,7 +74,7 @@ const columns: ColumnDef<ChampionOverviewChampion, any>[] = [
     columnHelper.accessor((row) => row.banPercentage, {
         id: 'Ban Rate',
         cell: (info) => `${info.getValue()}%`,
-        header: () => <span>Ban Rate</span>,
+        header: () => <span>Ban %</span>,
         meta: {
             isNumeric: true,
         },

--- a/src/components/SidebarWithHeader.tsx
+++ b/src/components/SidebarWithHeader.tsx
@@ -37,7 +37,8 @@ interface LinkItemProps {
 }
 const LinkItems: Array<LinkItemProps> = [
     { name: 'Home', icon: FiHome, route: '/' },
-    { name: 'Leaderboard', icon: FiAward, route: '/leaderboard' },
+    // TODO: HIDE THIS UNTIL SEASON 1
+    // { name: 'Leaderboard', icon: FiAward, route: '/leaderboard' },
     { name: 'Player Overview', icon: FiUsers, route: '/playerOverview' },
     { name: 'Champion Overview', icon: FiShield, route: '/championOverview' },
     { name: 'Match History', icon: FiCalendar, route: '/matchHistory' },

--- a/src/components/SprCard.tsx
+++ b/src/components/SprCard.tsx
@@ -7,6 +7,7 @@ import {
     StatLabel,
     Tooltip,
 } from '@chakra-ui/react';
+import { FiMinus } from 'react-icons/fi';
 import { Player } from '../types/domain/Player';
 import { SprTag } from './SprTag';
 
@@ -23,17 +24,23 @@ export const SprCard = ({
                 <Stat>
                     <Flex direction='column' align='center'>
                         <SprTag props={{ size: 'xl' }} player={player} />
-                        <StatLabel fontSize='20'>
-                            Season Power Ranking
-                        </StatLabel>
+                        <StatLabel fontSize='20'>SPR</StatLabel>
                         <Tooltip label='Average SPR change from recent games, up to the last five'>
                             <StatHelpText fontSize='14'>
-                                <StatArrow
-                                    type={
-                                        sprTrend > 0 ? 'increase' : 'decrease'
-                                    }
-                                />
-                                {sprTrend}
+                                {sprTrend !== 0 ? (
+                                    <>
+                                        <StatArrow
+                                            type={
+                                                sprTrend > 0
+                                                    ? 'increase'
+                                                    : 'decrease'
+                                            }
+                                        />
+                                        {sprTrend}
+                                    </>
+                                ) : (
+                                    'No Season 1 SPR'
+                                )}
                             </StatHelpText>
                         </Tooltip>
                     </Flex>

--- a/src/components/SprCard.tsx
+++ b/src/components/SprCard.tsx
@@ -39,7 +39,7 @@ export const SprCard = ({
                                         {sprTrend}
                                     </>
                                 ) : (
-                                    'No Season 1 SPR'
+                                    '0 -'
                                 )}
                             </StatHelpText>
                         </Tooltip>

--- a/src/components/SprTag.tsx
+++ b/src/components/SprTag.tsx
@@ -11,10 +11,14 @@ export const SprTag = ({
     player: Player;
     props?: { size?: string };
 }) => {
-    const rank = getMmrValue(player);
-    const playerIsRanked = rank > 0;
+    // TODO: Renable this for season 1
+    //const rank = getMmrValue(player);
+    //const playerIsRanked = rank > 0;
+    const rank = 0;
+    const playerIsRanked = false;
+
     return (
-        <Tooltip label='Season Power Ranking is a grade for player performance within a season'>
+        <Tooltip label='Season Power Ranking (SPR) is a grade for player performance within a season'>
             <Tag
                 textAlign='center'
                 bg={getMmrColor(rank)}

--- a/src/data/championClasses.ts
+++ b/src/data/championClasses.ts
@@ -50,7 +50,6 @@ export function championClassWinRates(champions: Champion[]) {
         } else {
             // this means that there are champions that we do not know about
             console.log('ERROR: unknown champion: ' + champion.name);
-            console.log(ChampionClassMap);
         }
     }
 

--- a/src/data/rewards.ts
+++ b/src/data/rewards.ts
@@ -1,0 +1,2 @@
+export const SEASON_0_BADGE =
+    'https://media.discordapp.net/attachments/1032887984179118131/1033640597656977438/pr_kraken_badge.png';

--- a/src/home/Home.tsx
+++ b/src/home/Home.tsx
@@ -1,4 +1,6 @@
-import { Flex, Heading } from '@chakra-ui/react';
+import { Button, Flex, Heading } from '@chakra-ui/react';
+import { FiArrowRight } from 'react-icons/fi';
+import { useNavigate } from 'react-router-dom';
 import { NewsCards } from '../news/NewsCards';
 
 const IS_SEASON_1 = true;
@@ -7,19 +9,26 @@ const backgroundVideo = IS_SEASON_1
     ? 'https://cdn.discordapp.com/attachments/972956581220192346/1032190900295716974/Neon_-_21368_VP9.webm'
     : 'https://blitz-cdn-videos.blitz.gg/ui/video/Homepage-Slide-One.webm';
 // 'https://screensavers.riotgames.com/v2/latest/content/original/AnimatedArt/animated-freljord.webm';
+//https://screensavers.riotgames.com/v2/latest/content/original/AnimatedArt/arcade-animated-02.webm
 
 export default function Home() {
+    const navigate = useNavigate();
+
+    const navigateToNews = () => {
+        navigate('/news');
+    };
+
     return (
         <Flex
             style={{
-                minHeight: '100vh',
+                minHeight: '90vh',
                 backgroundColor: '#282c34',
                 margin: -16,
                 position: 'relative',
             }}
             flexDirection='column'
         >
-            <Flex flex='1' minHeight='100vh' alignSelf='stretch'>
+            <Flex flex='1' minHeight='50vh' alignSelf='stretch'>
                 <div
                     style={{
                         position: 'relative',
@@ -83,10 +92,30 @@ export default function Home() {
                 backgroundColor='white'
                 flexDirection='column'
                 alignItems='center'
-                paddingBottom='16'
+                paddingTop='4'
+                paddingBottom='4'
             >
-                <Heading>LATEST UPDATES</Heading>
-                <NewsCards />
+                <Flex maxWidth='1024px' flexDirection='column' wrap='wrap'>
+                    <Button
+                        variant='ghost'
+                        flex={1}
+                        padding={1}
+                        size='md'
+                        alignSelf={'flex-end'}
+                        marginBottom='4'
+                        marginRight='1'
+                        flexDirection='row'
+                        onClick={navigateToNews}
+                    >
+                        <Flex alignItems='center'>
+                            <h1>All News</h1>
+                            <FiArrowRight />
+                        </Flex>
+                    </Button>
+                    <Flex wrap='wrap' flexDirection='row'>
+                        <NewsCards />
+                    </Flex>
+                </Flex>
             </Flex>
         </Flex>
     );

--- a/src/leaderboard/Leaderboard.tsx
+++ b/src/leaderboard/Leaderboard.tsx
@@ -81,7 +81,7 @@ const columns: ColumnDef<PlayerTableData, any>[] = [
     columnHelper.accessor((row) => row.totalGames, {
         id: 'totalGames',
         cell: (info) => info.getValue(),
-        header: () => <span>Total #</span>,
+        header: () => <span>Total Games</span>,
         meta: {
             isNumeric: true,
         },

--- a/src/leaderboard/Leaderboard.tsx
+++ b/src/leaderboard/Leaderboard.tsx
@@ -73,7 +73,7 @@ const columns: ColumnDef<PlayerTableData, any>[] = [
     columnHelper.accessor((row) => row.winPercentage, {
         id: 'winPercentage',
         cell: (info) => info.getValue(),
-        header: () => <span>Win Percentage</span>,
+        header: () => <span>Win %</span>,
         meta: {
             isNumeric: true,
         },
@@ -81,7 +81,7 @@ const columns: ColumnDef<PlayerTableData, any>[] = [
     columnHelper.accessor((row) => row.totalGames, {
         id: 'totalGames',
         cell: (info) => info.getValue(),
-        header: () => <span>Total Games</span>,
+        header: () => <span>Total #</span>,
         meta: {
             isNumeric: true,
         },

--- a/src/news/NewsCard.tsx
+++ b/src/news/NewsCard.tsx
@@ -22,24 +22,38 @@ export const NewsCard = React.memo(function NewsCard({
                 marginLeft: 8,
                 padding: 16,
                 width: '100%',
-                maxWidth: 750,
+                minWidth: 350,
                 cursor: 'pointer',
             }}
             onClick={onClick}
         >
-            <Flex flexDirection='column' alignItems={'flex-start'}>
+            <Flex
+                flexDirection='column'
+                alignItems={'flex-start'}
+                height='100%'
+            >
                 <h1 style={{ fontSize: 12 }}>{date}</h1>
                 <h1 style={{ fontSize: 30 }}>{title}</h1>
-                <div style={{ marginTop: 16, textAlign: 'left' }}>
-                    <p>{content}</p>
+                <div
+                    style={{
+                        marginTop: 16,
+                        textAlign: 'left',
+                        display: 'flex',
+                        flexDirection: 'column',
+                        flex: 1,
+                    }}
+                >
+                    <div style={{ flexGrow: 1 }}>
+                        <p>{content}</p>
+                    </div>
                     <Button
                         variant='ghost'
                         flex={1}
-                        padding={0}
+                        padding={1}
                         size='md'
                         alignSelf={'flex-end'}
                     >
-                        READ MORE
+                        Read More
                     </Button>
                 </div>
             </Flex>

--- a/src/news/NewsDetail.tsx
+++ b/src/news/NewsDetail.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
-import { useLoaderData } from 'react-router-dom';
+import { useLoaderData, useNavigate } from 'react-router-dom';
 
-import { Flex } from '@chakra-ui/react';
+import { Button, Flex } from '@chakra-ui/react';
 
 import { ARTICLES } from './NewsData';
 
 import { Error } from '../components/Error';
 import ARTICLE_10_20_2022 from './articles/10_20_2022';
+import { FiArrowLeft } from 'react-icons/fi';
 
 export async function loader(data: { params: any }) {
     return data.params.newsId;
@@ -23,6 +24,7 @@ function articleLookup(articleId: string) {
 
 export const NewsDetail = React.memo(function NewsDetail() {
     const articleId = useLoaderData() as string;
+    const navigate = useNavigate();
 
     // get the article
     const article = ARTICLES.find((article) => {
@@ -33,6 +35,10 @@ export const NewsDetail = React.memo(function NewsDetail() {
         return <Error error={'Something went wrong! Try again later.'} />;
     }
 
+    const navigateToNews = () => {
+        navigate('/news');
+    };
+
     return (
         <Flex flexDirection='column' alignItems='center' paddingBottom='16'>
             <Flex flexDirection='column' maxWidth='750'>
@@ -41,6 +47,22 @@ export const NewsDetail = React.memo(function NewsDetail() {
                     {article.title}
                 </h1>
                 <div style={{ marginTop: 16 }}>{articleLookup(article.id)}</div>
+                <Button
+                    variant='ghost'
+                    flex={1}
+                    padding={1}
+                    size='lg'
+                    alignSelf={'flex-end'}
+                    marginTop='16'
+                    marginRight='1'
+                    flexDirection='row'
+                    onClick={navigateToNews}
+                >
+                    <Flex alignItems='center'>
+                        <FiArrowLeft />
+                        <h1>Back to News</h1>
+                    </Flex>
+                </Button>
             </Flex>
         </Flex>
     );

--- a/src/news/NewsOverview.tsx
+++ b/src/news/NewsOverview.tsx
@@ -1,11 +1,19 @@
-import { Flex, Heading } from '@chakra-ui/react';
+import { Flex } from '@chakra-ui/react';
 import { NewsCards } from './NewsCards';
 
 export default function NewsOverview() {
     return (
-        <Flex flexDirection='column' alignItems='center' paddingBottom='16'>
-            <Heading>NEWS</Heading>
-            <NewsCards />
+        <Flex
+            flexDirection='column'
+            alignItems='center'
+            paddingTop='4'
+            paddingBottom='4'
+        >
+            <Flex maxWidth='1024px' flexDirection='column' wrap='wrap'>
+                <Flex wrap='wrap' flexDirection='row'>
+                    <NewsCards />
+                </Flex>
+            </Flex>
         </Flex>
     );
 }

--- a/src/news/articles/10_20_2022.tsx
+++ b/src/news/articles/10_20_2022.tsx
@@ -1,9 +1,13 @@
-import { Flex } from '@chakra-ui/react';
+import { Flex, Tag, TagLeftIcon, Text } from '@chakra-ui/react';
+import { GiWingedSword } from 'react-icons/gi';
+import { SEASON_0_BADGE } from '../../data/rewards';
+
+const paragraphStyle = { marginTop: 20 };
 
 export default function ARTICLE_10_20_2022() {
     return (
         <>
-            <p style={{ marginTop: 8 }}>
+            <p style={paragraphStyle}>
                 The Monday Night Customs Team has heard your voices on
                 progression in our custom games. Things like difficulty in
                 increasing MMR despite winning games and stagnant rankings are
@@ -12,7 +16,7 @@ export default function ARTICLE_10_20_2022() {
             <h1 style={{ fontSize: 20, fontWeight: 'bold', marginTop: 16 }}>
                 Introducing Seasons
             </h1>
-            <p style={{ marginTop: 8 }}>
+            <p style={paragraphStyle}>
                 As a result, we are excited to announce something new…
                 <b>Monday Night Customs Season 1!</b>
             </p>
@@ -23,40 +27,51 @@ export default function ARTICLE_10_20_2022() {
                 }
                 alt='season 1 splash'
             />
-            <p style={{ marginTop: 8 }}>
+            <p>
                 This will be a <b>timed event that occurs over 3 months</b>,
                 which will allow players to try to climb and do their best
                 before the season “resets” and the next season begins!
             </p>
-            <p style={{ marginTop: 8 }}>
-                Moving forward, a new season will be introduced every 3 months,
-                so players have the opportunity to prove themselves again and
-                get ranked.
+            <p style={paragraphStyle}>
+                Moving forward, a{' '}
+                <b>new season will be introduced every 3 months</b>, so players
+                have the opportunity to prove themselves again and get ranked.
             </p>
             <h1 style={{ fontSize: 20, fontWeight: 'bold', marginTop: 16 }}>
                 Season Power Ranking
             </h1>
-            <p style={{ marginTop: 8 }}>
+            <p style={paragraphStyle}>
                 How are players going to be ranked in each season?
             </p>
-            <p style={{ marginTop: 8 }}>
-                As part of seasons, we are introducing the concept of “Season
-                Power Ranking”, or “SPR” for short. SPR will be driven by a
-                different algorithm than existing MMRs. Moving forward, a new
-                “Leaderboard” on the MNC hub will be the go-to place to track
-                your progression throughout the season and compare how well you
-                are doing.
+            <p style={paragraphStyle}>
+                As part of seasons, we are introducing the concept of{' '}
+                <b>“Season Power Ranking”</b>, or “SPR” for short. SPR will be
+                driven by a different algorithm than existing MMRs. Moving
+                forward, a new “Leaderboard” on the MNC hub will be the go-to
+                place to track your progression throughout the season and
+                compare how well you are doing.
             </p>
-            <p style={{ marginTop: 8 }}>
-                SPR will only be finalized after you complete 30 qualifying
-                games. SPRs that aren’t “qualified” by the end of the season
-                won’t count! They’ll still appear on the leaderboard so players
-                can know how much they are changing, but will be deprioritized
-                and shown at the end of the list. With a season lasting 3
-                months, there will be plenty of time to play for a “qualified”
-                spot on the leaderboard.
+            <Flex style={{ margin: 'auto', justifyContent: 'center' }}>
+                <Tag textAlign='center' color={'gray.600'} alignSelf='center'>
+                    <TagLeftIcon as={GiWingedSword}></TagLeftIcon>
+                    <Text minW='30px'>{'SPR'}</Text>
+                </Tag>
+            </Flex>
+            <p style={paragraphStyle}>
+                SPR will only be finalized after you{' '}
+                <b>complete 30 qualifying games</b>. SPRs that aren’t
+                “qualified” by the end of the season won’t count! They’ll still
+                appear on the leaderboard so players can know how much they are
+                changing, but will be deprioritized and shown at the end of the
+                list. With a season lasting 3 months, there will be plenty of
+                time to play for a “qualified” spot on the leaderboard.
             </p>
-            <p style={{ marginTop: 8 }}>
+            <p style={paragraphStyle}>
+                Know that after your SPR is "qualified", your SPR can still
+                change! 30 games is just the minimum number of games to get your
+                rank counted for the season.
+            </p>
+            <p style={paragraphStyle}>
                 For all the players who enjoy the concept of MMR over all of
                 your games, don’t worry, the lifetime MMRs will continue to be
                 calculated and viewed on the player overview pages. MMR however
@@ -66,92 +81,108 @@ export default function ARTICLE_10_20_2022() {
             <h1 style={{ fontSize: 20, fontWeight: 'bold', marginTop: 16 }}>
                 Season Rewards
             </h1>
-            <p style={{ marginTop: 8 }}>
+            <p style={paragraphStyle}>
                 So why qualify for a season and get ranked? Well we are also
-                excited to announce Season Rewards! The player profiles are
-                getting a little bit of a cleanup, and with that we are excited
-                to announce Player Badges. These will appear on your profile,
-                and can be earned by accomplishing various tasks for a season.
-                To start, all players who currently have an MMR assigned get a
-                PROJECT: KRAKEN Badge to thank you for all the progress you have
-                already made and the contributions you brought to this
-                community!
+                excited to announce <b>Season Rewards</b>! The player profiles
+                are getting a little bit of a cleanup, and with that we are
+                excited to introduce <b>Player Badges</b>. These will appear on
+                your profile, and can be earned by accomplishing various tasks
+                for a season.
+            </p>
+            <p style={paragraphStyle}>
+                To kick things off, all players who currently have been placed
+                with an MMR assigned get a <b>PROJECT: KRAKEN Badge</b> to thank
+                you for all the progress you have already made and the
+                contributions you brought to this community!
             </p>
             <Flex padding='4'>
                 <img
                     style={{
                         margin: 'auto',
-                        width: 75,
-                        height: 75,
+                        width: 200,
+                        height: 200,
                         borderRadius: 8,
                     }}
-                    src={'https://i.redd.it/5l6oxzyzt0361.jpg'}
+                    src={SEASON_0_BADGE}
                     alt='kraken slayer'
                 />
             </Flex>
-            <p style={{ marginTop: 8 }}>
-                And we are also excited to present 3 badges for season 1!
+            <p>
+                And we are also excited to present 3 varations of the{' '}
+                <b>Season 1 Badge</b>!
             </p>
-            <Flex direction='row' justifyContent='center'>
-                <Flex padding='4'>
-                    <img
-                        style={{
-                            margin: 'auto',
-                            width: 75,
-                            height: 75,
-                            borderRadius: 8,
-                        }}
-                        src={
-                            'https://cdn-images.audioaddict.com/e/9/5/1/a/8/e951a8a9d049ef525dddbd92de34e462.png?size=120x120'
-                        }
-                        alt='vaporwave palm trees'
-                    />
-                </Flex>
-                <Flex padding='4'>
-                    <img
-                        style={{
-                            margin: 'auto',
-                            width: 75,
-                            height: 75,
-                            borderRadius: 8,
-                        }}
-                        src={
-                            'https://cdn-images.audioaddict.com/e/9/5/1/a/8/e951a8a9d049ef525dddbd92de34e462.png?size=120x120'
-                        }
-                        alt='vaporwave palm trees'
-                    />
-                </Flex>
-                <Flex padding='4'>
-                    <img
-                        style={{
-                            margin: 'auto',
-                            width: 75,
-                            height: 75,
-                            borderRadius: 8,
-                        }}
-                        src={
-                            'https://cdn-images.audioaddict.com/e/9/5/1/a/8/e951a8a9d049ef525dddbd92de34e462.png?size=120x120'
-                        }
-                        alt='vaporwave palm trees'
-                    />
+            <Flex justifyContent='center'>
+                <Flex direction='row' justifyContent='space-between'>
+                    <Flex padding='4' flexDirection={'column'}>
+                        <img
+                            style={{
+                                margin: 'auto',
+                                width: 100,
+                                height: 100,
+                                borderRadius: 8,
+                            }}
+                            src={
+                                'https://cdn-images.audioaddict.com/e/9/5/1/a/8/e951a8a9d049ef525dddbd92de34e462.png?size=120x120'
+                            }
+                            alt='vaporwave palm trees'
+                        />
+                        <h1 style={{ textAlign: 'center' }}>
+                            Season 1 Qualifer
+                        </h1>
+                    </Flex>
+                    <Flex padding='4' flexDirection={'column'}>
+                        <img
+                            style={{
+                                margin: 'auto',
+                                width: 100,
+                                height: 100,
+                                borderRadius: 8,
+                            }}
+                            src={
+                                'https://cdn-images.audioaddict.com/e/9/5/1/a/8/e951a8a9d049ef525dddbd92de34e462.png?size=120x120'
+                            }
+                            alt='vaporwave palm trees'
+                        />
+                        <h1 style={{ textAlign: 'center' }}>Season 1 Top 5</h1>
+                    </Flex>
+                    <Flex padding='4' flexDirection={'column'}>
+                        <img
+                            style={{
+                                margin: 'auto',
+                                width: 100,
+                                height: 100,
+                                borderRadius: 8,
+                            }}
+                            src={
+                                'https://cdn-images.audioaddict.com/e/9/5/1/a/8/e951a8a9d049ef525dddbd92de34e462.png?size=120x120'
+                            }
+                            alt='vaporwave palm trees'
+                        />
+                        <h1 style={{ textAlign: 'center' }}>Season 1 Master</h1>
+                    </Flex>
                 </Flex>
             </Flex>
-            <p style={{ marginTop: 8 }}>
+            <p>
                 These 3 badges are just the beginning of what we have in store
-                for season rewards.
+                for season rewards. You'll hear back from us again when we have
+                more rewards finalized!
             </p>
             <h1 style={{ fontSize: 20, fontWeight: 'bold', marginTop: 16 }}>
                 Season 1 Starts Soon!
             </h1>
-            <p style={{ marginTop: 8 }}>
-                Monday Night Customs Season 1 starts on November 14th! Players
-                who haven’t gotten an MMR yet before Season 1 have until then to
-                complete placements to get the PROJECT: KRAKEN badge.
+            <p style={paragraphStyle}>
+                <b>Monday Night Customs Season 1 starts on November 14th!</b>{' '}
+                Players who haven’t gotten an MMR yet before Season 1 have until
+                then to complete placements to get the PROJECT: KRAKEN badge.
             </p>
-            <p style={{ marginTop: 8 }}>
-                Alright, that’s everything we have to announce for now, good
-                luck everyone!
+            <p style={paragraphStyle}>
+                Alright, that’s everything we have to announce for now! If you
+                have any feedback or questions, don't hesistate to reach out on
+                our discord! Good luck on the abyss!
             </p>
+            <h1 style={{ fontSize: 20, fontWeight: 'bold', marginTop: 20 }}>
+                - TEAM TOXIC
+            </h1>
         </>
     );
 }

--- a/src/playerOverview/PlayerMmrSummary.tsx
+++ b/src/playerOverview/PlayerMmrSummary.tsx
@@ -1,4 +1,4 @@
-import { Flex } from '@chakra-ui/react';
+import { Flex, Tooltip as UiTooltip } from '@chakra-ui/react';
 import {
     CategoryScale,
     Chart as ChartJS,
@@ -11,7 +11,7 @@ import {
 } from 'chart.js';
 import React from 'react';
 import { Line } from 'react-chartjs-2';
-import { FiChevronDown, FiChevronUp, FiMinus } from 'react-icons/fi';
+import { FiCheck, FiChevronDown, FiChevronUp, FiMinus } from 'react-icons/fi';
 import { ToxicDataService } from '../services/toxicData/ToxicDataService';
 import { Player } from '../types/domain/Player';
 import {
@@ -99,22 +99,11 @@ export const PlayerMmrSummary = React.memo(function PlayerMmrSummary({
         <Flex direction='column'>
             {playerMmrPerMatchSliced.length > 1 ? (
                 <>
-                    <Flex direction='row' justify='center' align='center'>
-                        {/* 
-                            // TODO: This for season 1
-                            <MmrCard player={player} /> 
-                        */}
-                        <h1 style={{ fontSize: 60 }}>
-                            {`${mmrChangePercentage}`}
-                        </h1>
-                        {mmrChangePercentage === 0 ? (
-                            <FiMinus size={'60'} color={'orange'} />
-                        ) : mmrChangePercentage > 0 ? (
-                            <FiChevronUp size={'60'} color={'green'} />
-                        ) : (
-                            <FiChevronDown size={'60'} color={'red'} />
-                        )}
-                    </Flex>
+                    <UiTooltip label='Lifetime Match Making Rank (MMR) used for matchmaking purposes only'>
+                        <Flex direction='row' justify='center' align='center'>
+                            <h1 style={{ fontSize: 60 }}>{player.mmr}</h1>
+                        </Flex>
+                    </UiTooltip>
                     <Line
                         data={playerMmrPerMatchData}
                         style={{ maxHeight: 300 }}

--- a/src/playerOverview/PlayerOverview.tsx
+++ b/src/playerOverview/PlayerOverview.tsx
@@ -1,8 +1,10 @@
 import { Flex, Heading } from '@chakra-ui/react';
 import { ColumnDef, createColumnHelper, Row } from '@tanstack/react-table';
 import React from 'react';
+import { FiChevronDown, FiChevronUp, FiMinus } from 'react-icons/fi';
 import { useNavigate } from 'react-router-dom';
 import { SortableTable } from '../components/SortableTable';
+import { SprTag } from '../components/SprTag';
 import { ToxicDataService } from '../services/toxicData/ToxicDataService';
 import { Player } from '../types/domain/Player';
 import {
@@ -71,7 +73,7 @@ const columns: ColumnDef<PlayerTableData, any>[] = [
     columnHelper.accessor((row) => row.winPercentage, {
         id: 'winPercentage',
         cell: (info) => info.getValue(),
-        header: () => <span>Win Percentage</span>,
+        header: () => <span>Win %</span>,
         meta: {
             isNumeric: true,
         },
@@ -87,11 +89,57 @@ const columns: ColumnDef<PlayerTableData, any>[] = [
     columnHelper.accessor((row) => row.totalGames, {
         id: 'totalGames',
         cell: (info) => info.getValue(),
-        header: () => <span>Total Games</span>,
+        header: () => <span>Total #</span>,
         meta: {
             isNumeric: true,
         },
     }),
+    // TODO: For Season 1, put these back in
+    // columnHelper.accessor((row) => row.mmr, {
+    //     id: 'mmr',
+    //     cell: (info) => {
+    //         return <SprTag props={{ size: 'md' }} player={info.row.original} />;
+    //     },
+    //     header: () => <span>MMR</span>,
+    //     meta: {
+    //         isNumeric: true,
+    //     },
+    // }),
+    // columnHelper.accessor((row) => row.mmrChange, {
+    //     id: 'mmrChange',
+    //     cell: (info) => {
+    //         const value = info.getValue();
+    //         return (
+    //             <div
+    //                 style={{
+    //                     display: 'flex',
+    //                     alignItems: 'center',
+    //                     justifyContent: 'center',
+    //                     flexDirection: 'row',
+    //                 }}
+    //             >
+    //                 {value === -999 ? (
+    //                     <h1>-</h1>
+    //                 ) : (
+    //                     <>
+    //                         {value}
+    //                         {value === 0 ? (
+    //                             <FiMinus size={'24'} color={'orange'} />
+    //                         ) : value > 0 ? (
+    //                             <FiChevronUp size={'24'} color={'green'} />
+    //                         ) : (
+    //                             <FiChevronDown size={'24'} color={'red'} />
+    //                         )}
+    //                     </>
+    //                 )}
+    //             </div>
+    //         );
+    //     },
+    //     header: () => <span>MMR Trend</span>,
+    //     meta: {
+    //         isNumeric: true,
+    //     }
+    //}),
 ];
 
 export const PlayerOverview = React.memo(function PlayerOverview() {

--- a/src/playerOverview/PlayerOverview.tsx
+++ b/src/playerOverview/PlayerOverview.tsx
@@ -89,7 +89,7 @@ const columns: ColumnDef<PlayerTableData, any>[] = [
     columnHelper.accessor((row) => row.totalGames, {
         id: 'totalGames',
         cell: (info) => info.getValue(),
-        header: () => <span>Total #</span>,
+        header: () => <span>Total Games</span>,
         meta: {
             isNumeric: true,
         },

--- a/src/playerOverview/PlayerScreen.tsx
+++ b/src/playerOverview/PlayerScreen.tsx
@@ -48,7 +48,12 @@ export async function loader(data: { params: any }) {
     return data.params.playerId;
 }
 
-const initialSeasonSelectValue = 'all_time';
+enum SeasonType {
+    AllTime = 'all_time',
+    SeasonOne = 'season_1',
+}
+
+const initialSeasonSelectValue = SeasonType.AllTime;
 
 /**
  * Given a player, create an array of champions that player has played with image url populated
@@ -184,7 +189,7 @@ export const PlayerScreen = React.memo(function PlayerScreen() {
     );
 
     const onSeasonChange = (event: ChangeEvent<HTMLSelectElement>) => {
-        setSeason(event.target.value);
+        setSeason(event.target.value as SeasonType);
     };
 
     return (
@@ -275,9 +280,9 @@ export const PlayerScreen = React.memo(function PlayerScreen() {
             >
                 {
                     // add back in option for season 1 once season 1 launches
-                    // <option value={'season_1'}>{'Season 1'}</option>
+                    // <option value={SeasonType.SeasonOne}>{'Season 1'}</option>
                 }
-                <option value={'all_time'}>{'All Seasons'}</option>
+                <option value={SeasonType.AllTime}>{'All Seasons'}</option>
             </Select>
             <Tabs isFitted={true} maxWidth='100%'>
                 <TabList>


### PR DESCRIPTION
This is a big set of changes to align with neil's design requests. 

Home banner is now only half the screen, with hte news section appearing belong the banner. 
Made news cards match comps
Formatting of the News detail page is better now
Finalized article 1 content (only thing missing now is the genesis badges)
Added a lot of tooltips explaining what is happening in the context of MMR, etc
Finalized logic around project:kraken badging
Commented a lot of code that will not be used until genesis debuts. 
Removed MMR from player overview table
Removed MMR trend calculation from MMR summary, just showing the latest MMR now