### PR TITLE
Fix SPR Trending, clean up leaderboard, clean up slideshow

### DIFF
--- a/src/admin/Slideshow.tsx
+++ b/src/admin/Slideshow.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { getMmrColor } from '../utils/mmrHelpers';
+import { getSprColor } from '../utils/sprHelpers';
 
 import CSS from 'csstype';
 import { PlayerCard } from './slideshow/PlayerCard';
@@ -89,7 +89,7 @@ const StatsRow = (props: {
                     fontWeight: 'bold',
                     color:
                         props.valueType === StatsRowValueType.mmr
-                            ? getMmrColor(props.value ?? 0)
+                            ? getSprColor(props.value ?? 0)
                             : 'white',
                     textShadow:
                         props.valueType === StatsRowValueType.mmr
@@ -112,10 +112,12 @@ export const Slideshow = React.memo(function Slideshow({
 }: {
     transparentBackground?: boolean;
 }) {
-    const playersResponse = ToxicDataService.usePlayers();
+    // TODO: read the hydra data based on a url query parameter
+    const SEASON_NUMBER = 1;
+    const playersResponse = ToxicDataService.usePlayers(SEASON_NUMBER);
     const players = playersResponse.data ?? [];
 
-    const championsResponse = ToxicDataService.useChampions();
+    const championsResponse = ToxicDataService.useChampions(SEASON_NUMBER);
     const champions = Array.from(Object.values(championsResponse.data ?? {}));
 
     const [slideNo, setSlideNo] = useState(0);
@@ -125,14 +127,16 @@ export const Slideshow = React.memo(function Slideshow({
     // sort the players by MMR
     const sortedPlayers = players
         ? players
-              .filter((value) => (value.wins ?? 0) + (value.losses ?? 0) >= 10)
+              // ignore the placements filter
+              //.filter((value) => (value.wins ?? 0) + (value.losses ?? 0) >= 10)
               .sort((a, b) => (b.glicko ?? 0) - (a.glicko ?? 0))
         : [];
 
     // sort the champions by win rate
     const sortedChampions = champions
         ? champions
-              .filter((value) => value.totalGames >= 10)
+              // ignore the placements filter
+              //.filter((value) => value.totalGames >= 10)
               .sort((a, b) => b.winPercentage - a.winPercentage)
         : [];
 
@@ -173,6 +177,8 @@ export const Slideshow = React.memo(function Slideshow({
         return null;
     }
 
+    const LATEST_RANKED_STANDINGS_HEADER = 'LATEST RANKED STANDINGS';
+
     return (
         <div
             style={{
@@ -189,7 +195,9 @@ export const Slideshow = React.memo(function Slideshow({
         >
             <div style={slideNo === 0 ? visibleContainer : hiddenContainer}>
                 <div style={styles.content}>
-                    <h1 style={styles.header}>LATEST MMR STANDINGS</h1>
+                    <h1 style={styles.header}>
+                        {LATEST_RANKED_STANDINGS_HEADER}
+                    </h1>
                     <StatsRow
                         name={sortedPlayers[0].name}
                         value={sortedPlayers[0].glicko}
@@ -214,7 +222,9 @@ export const Slideshow = React.memo(function Slideshow({
             </div>
             <div style={slideNo === 1 ? visibleContainer : hiddenContainer}>
                 <div style={styles.content}>
-                    <h1 style={styles.header}>{'LATEST MMR STANDINGS'}</h1>
+                    <h1 style={styles.header}>
+                        {LATEST_RANKED_STANDINGS_HEADER}
+                    </h1>
                     <StatsRow
                         name={sortedPlayers[4].name}
                         value={sortedPlayers[4].glicko}
@@ -239,7 +249,9 @@ export const Slideshow = React.memo(function Slideshow({
             </div>
             <div style={slideNo === 2 ? visibleContainer : hiddenContainer}>
                 <div style={styles.content}>
-                    <h1 style={styles.header}>{'LATEST MMR STANDINGS'}</h1>
+                    <h1 style={styles.header}>
+                        {LATEST_RANKED_STANDINGS_HEADER}
+                    </h1>
                     <StatsRow
                         name={sortedPlayers[8].name}
                         value={sortedPlayers[8].glicko}
@@ -264,7 +276,9 @@ export const Slideshow = React.memo(function Slideshow({
             </div>
             <div style={slideNo === 3 ? visibleContainer : hiddenContainer}>
                 <div style={styles.content}>
-                    <h1 style={styles.header}>{'LATEST MMR STANDINGS'}</h1>
+                    <h1 style={styles.header}>
+                        {LATEST_RANKED_STANDINGS_HEADER}
+                    </h1>
                     <StatsRow
                         name={sortedPlayers[12].name}
                         value={sortedPlayers[12].glicko}

--- a/src/admin/slideshow/PlayerCard.tsx
+++ b/src/admin/slideshow/PlayerCard.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { getMmrColor } from '../../utils/mmrHelpers';
+import { getSprColor } from '../../utils/sprHelpers';
 
 import CSS from 'csstype';
 import { Player } from '../../types/domain/Player';
@@ -52,7 +52,7 @@ export const PlayerCard = (props: { player: Player }) => {
     const mmrTextStyle: CSS.Properties = {
         fontSize: '60px',
         fontWeight: 'bold',
-        color: getMmrColor(props.player.glicko ?? 0),
+        color: getSprColor(props.player.glicko ?? 0),
         textShadow: '2px 2px 7px black',
         textAlign: 'start',
     };

--- a/src/components/SprTag.tsx
+++ b/src/components/SprTag.tsx
@@ -12,10 +12,12 @@ export const SprTag = ({
     props?: { size?: string };
 }) => {
     let spr = 0;
+    let isQualified = true;
     if (value) {
         if (typeof value === 'number') {
             spr = value;
         } else if (typeof value === 'object') {
+            isQualified = (value.wins ?? 0) + (value.losses ?? 0) >= 30;
             spr = getSprValue(value);
         }
     }
@@ -24,13 +26,16 @@ export const SprTag = ({
         <Tooltip label='Season Power Ranking (SPR) is a grade for player performance within a season'>
             <Tag
                 textAlign='center'
-                bg={getSprColor(spr)}
+                bg={isQualified ? getSprColor(spr) : undefined}
                 color={'gray.600'}
                 size={props?.size}
                 minW='100%'
             >
                 <TagLeftIcon as={GiWingedSword}></TagLeftIcon>
-                <Text minW='30px'>{spr > 0 ? spr : '—'}</Text>
+                <Text minW='30px'>
+                    {spr > 0 ? spr : '—'}
+                    {isQualified ? undefined : '*'}
+                </Text>
             </Tag>
         </Tooltip>
     );

--- a/src/components/SummonerCollage.tsx
+++ b/src/components/SummonerCollage.tsx
@@ -5,12 +5,8 @@ import { Champion } from '../types/domain/Champion';
 import { Player } from '../types/domain/Player';
 import { getChampionImage } from '../utils/championImageHelpers';
 
-export function getRandomIcon(id: number) {
-    return (
-        'https://ddragon.leagueoflegends.com/cdn/12.18.1/img/profileicon/' +
-        (588 + id) +
-        '.png'
-    );
+export function getPlaceholderIcon() {
+    return 'https://upload.wikimedia.org/wikipedia/commons/thumb/7/7c/Profile_avatar_placeholder_large.png/120px-Profile_avatar_placeholder_large.png?20150327203541';
 }
 
 export function sortChampionsByWinRate(player: Player): Champion[] {
@@ -59,7 +55,7 @@ export const SummonerCollage = React.memo(function Error({
                         <img
                             alt='random icon 1'
                             style={{ flex: 1 }}
-                            src={getRandomIcon(0)}
+                            src={getPlaceholderIcon()}
                         />
                     </Box>
                 )}
@@ -76,7 +72,7 @@ export const SummonerCollage = React.memo(function Error({
                         <img
                             alt='random icon 2'
                             style={{ flex: 1 }}
-                            src={getRandomIcon(2)}
+                            src={getPlaceholderIcon()}
                         />
                     </Box>
                 )}
@@ -95,7 +91,7 @@ export const SummonerCollage = React.memo(function Error({
                         <img
                             alt='random icon 3'
                             style={{ flex: 1 }}
-                            src={getRandomIcon(3)}
+                            src={getPlaceholderIcon()}
                         />
                     </Box>
                 )}
@@ -112,7 +108,7 @@ export const SummonerCollage = React.memo(function Error({
                         <img
                             alt='random champion icon 4'
                             style={{ flex: 1 }}
-                            src={getRandomIcon(1)}
+                            src={getPlaceholderIcon()}
                         />
                     </Box>
                 )}

--- a/src/leaderboard/Leaderboard.tsx
+++ b/src/leaderboard/Leaderboard.tsx
@@ -123,41 +123,41 @@ const columns: ColumnDef<PlayerTableData, any>[] = [
             isNumeric: true,
         },
     }),
-    columnHelper.accessor((row) => row.mmrChange, {
-        id: 'mmrChange',
-        cell: (info) => {
-            const value = info.getValue();
-            return (
-                <div
-                    style={{
-                        display: 'flex',
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                        flexDirection: 'row',
-                    }}
-                >
-                    {value === -999 ? (
-                        <h1>-</h1>
-                    ) : (
-                        <>
-                            {value}
-                            {value === 0 ? (
-                                <FiMinus size={'24'} color={'orange'} />
-                            ) : value > 0 ? (
-                                <FiChevronUp size={'24'} color={'green'} />
-                            ) : (
-                                <FiChevronDown size={'24'} color={'red'} />
-                            )}
-                        </>
-                    )}
-                </div>
-            );
-        },
-        header: () => <span>SPR Trend</span>,
-        meta: {
-            isNumeric: true,
-        },
-    }),
+    // columnHelper.accessor((row) => row.mmrChange, {
+    //     id: 'mmrChange',
+    //     cell: (info) => {
+    //         const value = info.getValue();
+    //         return (
+    //             <div
+    //                 style={{
+    //                     display: 'flex',
+    //                     alignItems: 'center',
+    //                     justifyContent: 'center',
+    //                     flexDirection: 'row',
+    //                 }}
+    //             >
+    //                 {value === -999 ? (
+    //                     <h1>-</h1>
+    //                 ) : (
+    //                     <>
+    //                         {value}
+    //                         {value === 0 ? (
+    //                             <FiMinus size={'24'} color={'orange'} />
+    //                         ) : value > 0 ? (
+    //                             <FiChevronUp size={'24'} color={'green'} />
+    //                         ) : (
+    //                             <FiChevronDown size={'24'} color={'red'} />
+    //                         )}
+    //                     </>
+    //                 )}
+    //             </div>
+    //         );
+    //     },
+    //     header: () => <span>SPR Trend</span>,
+    //     meta: {
+    //         isNumeric: true,
+    //     },
+    // }),
 ];
 
 export const Leaderboard = React.memo(function Leaderboard() {

--- a/src/playerOverview/PlayerMmrSummary.tsx
+++ b/src/playerOverview/PlayerMmrSummary.tsx
@@ -13,11 +13,7 @@ import React from 'react';
 import { Line } from 'react-chartjs-2';
 import { ToxicDataService } from '../services/toxicData/ToxicDataService';
 import { Player } from '../types/domain/Player';
-import {
-    getMmrTrendingChange,
-    getMmrValue,
-    mapMmrHistoryCollectionToPlayerMmrHistoryMap,
-} from '../utils/mmrHelpers';
+import { getMmrValue } from '../utils/mmrHelpers';
 
 ChartJS.register(
     PointElement,

--- a/src/playerOverview/PlayerScreen.tsx
+++ b/src/playerOverview/PlayerScreen.tsx
@@ -251,19 +251,18 @@ export const PlayerScreen = React.memo(function PlayerScreen() {
                             </Flex>
                             <AccoladesCollection player={player} />
                         </Flex>
-                        <Flex margin='4' justifyContent='center'>
-                            {
-                                // TODO: For season 1, we need to add the SPR rank here
-                            }
-                            <SprCard
-                                value={
-                                    season?.value === Seasons.ALL_SEASONS
-                                        ? undefined
-                                        : player
-                                }
-                                sprTrend={0}
-                            />
-                        </Flex>
+                        {season?.value !== Seasons.ALL_SEASONS ? (
+                            <Flex margin='4' justifyContent='center'>
+                                <SprCard
+                                    value={
+                                        season?.value === Seasons.ALL_SEASONS
+                                            ? undefined
+                                            : seasonPlayer
+                                    }
+                                    sprTrend={0}
+                                />
+                            </Flex>
+                        ) : null}
                         <Flex margin='4' flex='1' maxWidth='320'>
                             <Radar data={chartData} />
                         </Flex>

--- a/src/playerOverview/PlayerScreen.tsx
+++ b/src/playerOverview/PlayerScreen.tsx
@@ -44,6 +44,10 @@ import {
     teammateColumns,
 } from './playerScreenColumnHelper';
 import { PlayerScreenChampion } from './types/PlayerScreenChampion';
+import {
+    getSprTrendingChange,
+    mapSprHistoryCollectionToPlayerSprHistoryMap,
+} from '../utils/sprHelpers';
 
 export async function loader(data: { params: any }) {
     return data.params.playerId;
@@ -118,6 +122,16 @@ export const PlayerScreen = React.memo(function PlayerScreen() {
         season?.value.id
     );
     const matchHistory = matchHistoryResponse.data ?? [];
+
+    const glickoPerMatchResponse = ToxicDataService.useGlickoPerMatch(
+        season?.value.id
+    );
+    const glickoPerMatch = glickoPerMatchResponse.data ?? [];
+    const glickoPerMatchMap =
+        mapSprHistoryCollectionToPlayerSprHistoryMap(glickoPerMatch);
+    const sprChangePercentage = getSprTrendingChange(
+        glickoPerMatchMap[player ? player.name : ''] ?? []
+    );
 
     // only recompute the player classes when are looking at a new player
     const playerClasses = useMemo(
@@ -259,7 +273,7 @@ export const PlayerScreen = React.memo(function PlayerScreen() {
                                             ? undefined
                                             : seasonPlayer
                                     }
-                                    sprTrend={0}
+                                    sprTrend={sprChangePercentage}
                                 />
                             </Flex>
                         ) : null}

--- a/src/services/toxicData/ToxicDataService.ts
+++ b/src/services/toxicData/ToxicDataService.ts
@@ -393,10 +393,12 @@ export const ToxicDataService = {
             };
         }
     },
-    useGlickoPerMatch: (): {
+    useGlickoPerMatch: (
+        season?: number
+    ): {
         data: GlickoHistoryItem[] | undefined;
     } & ServiceResponseBase => {
-        const glickoPerMatchResponse = useGlickoPerMatch();
+        const glickoPerMatchResponse = useGlickoPerMatch(season);
 
         if (glickoPerMatchResponse.data) {
             const glickoData = glickoPerMatchResponse.data;

--- a/src/utils/mmrHelpers.ts
+++ b/src/utils/mmrHelpers.ts
@@ -1,4 +1,3 @@
-import { GlickoHistoryItem } from '../types/domain/GlickoHistoryItem';
 import { Player } from '../types/domain/Player';
 
 const TRUESKILL_MMR_CONVERSION_FACTOR = 100;
@@ -9,59 +8,4 @@ export function getMmrValue(player: Player): number {
     return player.trueskill
         ? Math.round(player.trueskill * TRUESKILL_MMR_CONVERSION_FACTOR)
         : 0;
-}
-
-export function getMmrColor(mmr: number) {
-    return mmr > 0
-        ? `hsl(${120 * ((1800 - mmr) / 1800) * 4 * -1 + 120}, 100%, 67%)`
-        : 'transparent';
-}
-
-/**
- * Takes in a collection of match history items and returns a map of
- * player name to an collection of their games (with the game id and the player's resulting mmr for that game)
- */
-export function mapMmrHistoryCollectionToPlayerMmrHistoryMap(
-    data: GlickoHistoryItem[]
-): { [key: string]: { gameId: number; mmr: number }[] } {
-    const playerMMR: { [key: string]: { gameId: number; mmr: number }[] } = {};
-
-    for (let i = 0; i < data.length; i++) {
-        const match = data[i];
-        for (const playerName of Object.keys(match.players)) {
-            if (playerMMR[playerName] === undefined) {
-                playerMMR[playerName] = [];
-            }
-
-            if (playerMMR[playerName].length > 0) {
-                let mostRecent =
-                    playerMMR[playerName][playerMMR[playerName].length - 1];
-                if (mostRecent.mmr === match.players[playerName]) continue;
-            }
-
-            playerMMR[playerName].push({
-                gameId: i + 1,
-                mmr: match.players[playerName],
-            });
-        }
-    }
-    return playerMMR;
-}
-
-/**
- * Takes a collection of a player's mmr history items, and returns the average mmr change
- * from the most recent games, up to five games worth of mmr changes
- */
-export function getMmrTrendingChange(data: { gameId: number; mmr: number }[]) {
-    // this will return an array of the last 5 items (or if less than 5 items, the entire collection)
-    const recentMatches = data.slice(-6);
-    const matchCount = recentMatches.length;
-    if (matchCount <= 1) {
-        return 0;
-    }
-    const totalChange =
-        recentMatches[matchCount - 1].mmr - recentMatches[0].mmr;
-    const trend = totalChange / (matchCount - 1);
-    // return rounded to nearest decimal
-    return parseFloat(trend.toFixed(1));
 }

--- a/src/utils/sprHelpers.ts
+++ b/src/utils/sprHelpers.ts
@@ -1,3 +1,4 @@
+import { GlickoHistoryItem } from '../types/domain/GlickoHistoryItem';
 import { Player } from '../types/domain/Player';
 
 const MIN_GAMES_REQUIRED = 30;
@@ -17,4 +18,53 @@ export function getSprColor(spr: number) {
 
 export function isPlayerRanked(player: Player): boolean {
     return (player.wins ?? 0) + (player.losses ?? 0) >= MIN_GAMES_REQUIRED;
+}
+
+/**
+ * Takes in a collection of match history items and returns a map of
+ * player name to an collection of their games (with the game id and the player's resulting spr for that game)
+ */
+export function mapSprHistoryCollectionToPlayerSprHistoryMap(
+    data: GlickoHistoryItem[]
+): { [key: string]: { gameId: number; spr: number }[] } {
+    const playerSPR: { [key: string]: { gameId: number; spr: number }[] } = {};
+
+    for (let i = 0; i < data.length; i++) {
+        const match = data[i];
+        for (const playerName of Object.keys(match.players)) {
+            if (playerSPR[playerName] === undefined) {
+                playerSPR[playerName] = [];
+            }
+
+            if (playerSPR[playerName].length > 0) {
+                let mostRecent =
+                    playerSPR[playerName][playerSPR[playerName].length - 1];
+                if (mostRecent.spr === match.players[playerName]) continue;
+            }
+
+            playerSPR[playerName].push({
+                gameId: i + 1,
+                spr: match.players[playerName],
+            });
+        }
+    }
+    return playerSPR;
+}
+
+/**
+ * Takes a collection of a player's spr history items, and returns the average spr change
+ * from the most recent games, up to five games worth of spr changes
+ */
+export function getSprTrendingChange(data: { gameId: number; spr: number }[]) {
+    // this will return an array of the last 5 items (or if less than 5 items, the entire collection)
+    const recentMatches = data.slice(-6);
+    const matchCount = recentMatches.length;
+    if (matchCount <= 1) {
+        return 0;
+    }
+    const totalChange =
+        recentMatches[matchCount - 1].spr - recentMatches[0].spr;
+    const trend = totalChange / (matchCount - 1);
+    // return rounded to nearest decimal
+    return parseFloat(trend.toFixed(1));
 }


### PR DESCRIPTION
IM BACK!

Went ahead and cleaned up the SPR code such that the SPR cards now have a working SPR trending, but I haven't added to this actual leaderboard because of width issues. 

I also cleaned up the logic on teh slideshow to scope down to season 1 information.

Finally, moved some helpers from MMR helpers since they aren't actually MMR related, but glicko (SPR) related now. The MMR helpers are scoped strictly to matchmaking.

Fixed the longstanding weird placeholder icons for champions to have better looking placeholders. 