### PR TITLE
Add the ability to view pick ban rate of champions

### DIFF
--- a/src/championOverview/ChampionOverview.tsx
+++ b/src/championOverview/ChampionOverview.tsx
@@ -65,7 +65,7 @@ const columns: ColumnDef<ChampionOverviewChampion, any>[] = [
     }),
     columnHelper.accessor((row) => row.pickPercentage, {
         id: 'Pick Rate',
-        cell: (info) => `${info.getValue()}%`,
+        cell: (info) => `${Math.round(info.getValue())}%`,
         header: () => <span>Pick %</span>,
         meta: {
             isNumeric: true,
@@ -73,7 +73,7 @@ const columns: ColumnDef<ChampionOverviewChampion, any>[] = [
     }),
     columnHelper.accessor((row) => row.banPercentage, {
         id: 'Ban Rate',
-        cell: (info) => `${info.getValue()}%`,
+        cell: (info) => `${Math.round(info.getValue())}%`,
         header: () => <span>Ban %</span>,
         meta: {
             isNumeric: true,

--- a/src/championOverview/ChampionPickBanView.tsx
+++ b/src/championOverview/ChampionPickBanView.tsx
@@ -1,0 +1,109 @@
+import { Flex, Tooltip as UiTooltip } from '@chakra-ui/react';
+import {
+    CategoryScale,
+    Chart as ChartJS,
+    Filler,
+    Legend,
+    LinearScale,
+    LineElement,
+    PointElement,
+    Tooltip,
+} from 'chart.js';
+import React from 'react';
+import { Line } from 'react-chartjs-2';
+import { ToxicDataService } from '../services/toxicData/ToxicDataService';
+import { Champion } from '../types/domain/Champion';
+import { Player } from '../types/domain/Player';
+import { getMmrValue } from '../utils/mmrHelpers';
+
+ChartJS.register(
+    PointElement,
+    LineElement,
+    CategoryScale,
+    LinearScale,
+    Filler,
+    Tooltip,
+    Legend
+);
+
+function processChampion(data: { pick: number; ban: number }[]): {
+    pickRate: { x: number; y: number }[];
+    banRate: { x: number; y: number }[];
+} {
+    const pickRate = data.map((value, index) => {
+        return { x: index, y: Math.round(value.pick) };
+    });
+
+    const banRate = data.map((value, index) => {
+        return { x: index, y: Math.round(value.ban) };
+    });
+
+    return {
+        pickRate,
+        banRate,
+    };
+}
+
+export const ChampionPickBanView = React.memo(function ChampionPickBanView({
+    champion,
+}: {
+    champion: Champion;
+}) {
+    if (champion.pickBanHistory === undefined) {
+        return null;
+    }
+
+    const { pickRate, banRate } = processChampion(champion.pickBanHistory);
+
+    const playerMmrPerMatchData = {
+        datasets: [
+            {
+                label: 'Pick Rate',
+                data: pickRate,
+                fill: true,
+                backgroundColor: 'rgba(99, 132, 255, 0.5)',
+                borderColor: 'rgb(99, 132, 255, 0.5)',
+                pointBackgroundColor: 'rgb(99, 132, 255)',
+                pointBorderColor: '#fff',
+                pointHoverBackgroundColor: '#fff',
+                pointHoverBorderColor: 'rgb(99, 132, 225)',
+            },
+            {
+                label: 'Ban Rate',
+                data: banRate,
+                fill: true,
+                backgroundColor: 'rgba(255, 99, 132, 0.2)',
+                borderColor: 'rgb(255, 99, 132)',
+                pointBackgroundColor: 'rgb(255, 99, 132)',
+                pointBorderColor: '#fff',
+                pointHoverBackgroundColor: '#fff',
+                pointHoverBorderColor: 'rgb(255, 99, 132)',
+            },
+        ],
+    };
+
+    return (
+        <Line
+            data={playerMmrPerMatchData}
+            style={{ maxHeight: 300 }}
+            options={{
+                scales: {
+                    x: {
+                        type: 'linear',
+                        min: 1,
+                        max: champion.pickBanHistory.length,
+                    },
+                    y: {
+                        suggestedMin: 0,
+                        suggestedMax: 100,
+                    },
+                },
+                plugins: {
+                    legend: {
+                        display: true,
+                    },
+                },
+            }}
+        />
+    );
+});

--- a/src/championOverview/ChampionScreen.tsx
+++ b/src/championOverview/ChampionScreen.tsx
@@ -1,4 +1,5 @@
 import { Flex } from '@chakra-ui/layout';
+import { Tabs, TabList, Tab, TabPanels, TabPanel } from '@chakra-ui/react';
 import { ColumnDef, createColumnHelper } from '@tanstack/react-table';
 import React from 'react';
 import { useLoaderData, useNavigate } from 'react-router-dom';
@@ -11,7 +12,9 @@ import { DataDragonService } from '../services/dataDragon/DataDragonService';
 import { ToxicDataService } from '../services/toxicData/ToxicDataService';
 import { Champion } from '../types/domain/Champion';
 import { Player } from '../types/domain/Player';
+import { Seasons } from '../types/domain/Season';
 import { getChampionImage } from '../utils/championImageHelpers';
+import { ChampionPickBanView } from './ChampionPickBanView';
 
 export async function loader(data: { params: any }) {
     return data.params.championId;
@@ -132,10 +135,10 @@ export const ChampionScreen = React.memo(function ChampionScreen() {
                 return (prevValue !== '' ? prevValue + ',' : '') + currentValue;
             }, ''),
             'Ban Rate': champion.banPercentage
-                ? `${champion.banPercentage}%`
+                ? `${Math.round(champion.banPercentage)}%`
                 : 'N/A',
             'Pick Rate': champion.pickPercentage
-                ? `${champion.pickPercentage}%`
+                ? `${Math.round(champion.pickPercentage)}%`
                 : 'N/A',
         },
     };
@@ -145,17 +148,35 @@ export const ChampionScreen = React.memo(function ChampionScreen() {
             <Flex marginBottom={8}>
                 <StatsCard stats={statsCardChampion} />
             </Flex>
-            <SortableTable
-                columns={columns}
-                data={championPlayerData}
-                getRowProps={(row: any) => {
-                    return {
-                        onClick: () => {
-                            navigate('/playerOverview/' + row.getValue('name'));
-                        },
-                    };
-                }}
-            />
+            <Tabs isFitted={true} maxWidth='100%'>
+                <TabList>
+                    <Tab>Match History</Tab>
+                    <Tab>Pick & Ban Record</Tab>
+                </TabList>
+                <TabPanels>
+                    <TabPanel>
+                        <SortableTable
+                            columns={columns}
+                            data={championPlayerData}
+                            getRowProps={(row: any) => {
+                                return {
+                                    onClick: () => {
+                                        navigate(
+                                            '/playerOverview/' +
+                                                row.getValue('name')
+                                        );
+                                    },
+                                };
+                            }}
+                        />
+                    </TabPanel>
+                    <TabPanel>
+                        <Flex minWidth={'600'}>
+                            <ChampionPickBanView champion={champion} />
+                        </Flex>
+                    </TabPanel>
+                </TabPanels>
+            </Tabs>
         </Flex>
     );
 });

--- a/src/services/toxicData/ToxicDataService.ts
+++ b/src/services/toxicData/ToxicDataService.ts
@@ -369,6 +369,7 @@ export const ToxicDataService = {
                 pickPercentage: championPickBanData
                     ? championPickBanData[championPickBanData.length - 1].pick
                     : undefined,
+                pickBanHistory: championPickBanData,
             };
 
             return {

--- a/src/services/toxicData/ToxicDataService.ts
+++ b/src/services/toxicData/ToxicDataService.ts
@@ -310,10 +310,18 @@ export const ToxicDataService = {
 
             // loop through data, and update the pick/ban rate
             for (const championName of Object.keys(data)) {
+                const championPickBanData = championPickBanMap[championName];
+
                 data[championName] = {
                     ...data[championName],
-                    banPercentage: championPickBanMap[championName]?.ban,
-                    pickPercentage: championPickBanMap[championName]?.pick,
+                    banPercentage: championPickBanData
+                        ? championPickBanData[championPickBanData.length - 1]
+                              .ban
+                        : undefined,
+                    pickPercentage: championPickBanData
+                        ? championPickBanData[championPickBanData.length - 1]
+                              .pick
+                        : undefined,
                 };
             }
 
@@ -351,11 +359,16 @@ export const ToxicDataService = {
             const matchData = matchHistoryResponse.data;
             const matches = matchData ? mapMatchHistory(matchData) : [];
             const championPickBanMap = getChampionPickBanMap(matches);
+            const championPickBanData = championPickBanMap[id];
 
             const data = {
                 ...champion,
-                banPercentage: championPickBanMap[id]?.ban,
-                pickPercentage: championPickBanMap[id]?.pick,
+                banPercentage: championPickBanData
+                    ? championPickBanData[championPickBanData.length - 1].ban
+                    : undefined,
+                pickPercentage: championPickBanData
+                    ? championPickBanData[championPickBanData.length - 1].pick
+                    : undefined,
             };
 
             return {

--- a/src/services/toxicData/dataMapper.ts
+++ b/src/services/toxicData/dataMapper.ts
@@ -238,14 +238,18 @@ export function mapGlickoPerMatch(
     });
 }
 
-// matches is expected to be listed from newest to oldest
+/**
+ * Take a collection of matches and return a map of champions to historical pick ban rates across those games
+ * @param latestMatchList A list of matches ordered from oldest to newest
+ * @returns A map, where the key is champion name, and the value is an array of historical pick/ban rates across all matches
+ */
 export function getChampionPickBanMap(latestMatchList: Match[]): {
     [id: string]: { pick: number; ban: number }[];
 } {
     // the
     const matches = latestMatchList.reverse();
     const pickBan: {
-        [id: string]: { pick: number; ban: number }[];
+        [id: string]: { pick: number; ban: number; matchNo: number }[];
     } = {};
 
     // initialize all champion pick bans to 0%
@@ -272,6 +276,7 @@ export function getChampionPickBanMap(latestMatchList: Match[]): {
                     (((latestPickBanData.ban / 100) * (matchNo - 1)) /
                         matchNo) *
                     100,
+                matchNo,
             });
         }
 
@@ -290,6 +295,7 @@ export function getChampionPickBanMap(latestMatchList: Match[]): {
                     (((latestPickBanData.ban / 100) * (matchNo - 1)) /
                         matchNo) *
                     100,
+                matchNo,
             });
         }
 
@@ -311,6 +317,7 @@ export function getChampionPickBanMap(latestMatchList: Match[]): {
                         (((latestPickBanData.ban / 100) * (matchNo - 1) + 1) /
                             matchNo) *
                         100,
+                    matchNo,
                 });
             }
         }
@@ -333,6 +340,7 @@ export function getChampionPickBanMap(latestMatchList: Match[]): {
                         (((latestPickBanData.ban / 100) * (matchNo - 1) + 1) /
                             matchNo) *
                         100,
+                    matchNo,
                 });
             }
         }
@@ -341,7 +349,7 @@ export function getChampionPickBanMap(latestMatchList: Match[]): {
         for (const championName of Object.keys(pickBan)) {
             if (pickBan[championName].length !== matchNo) {
                 if (pickBan[championName].length === 0) {
-                    pickBan[championName].push({ pick: 0, ban: 0 });
+                    pickBan[championName].push({ pick: 0, ban: 0, matchNo: 0 });
                 } else {
                     pickBan[championName].push({
                         pick:
@@ -354,6 +362,7 @@ export function getChampionPickBanMap(latestMatchList: Match[]): {
                                 (matchNo - 1)) /
                                 matchNo) *
                             100,
+                        matchNo,
                     });
                 }
             }

--- a/src/services/toxicData/dataMapper.ts
+++ b/src/services/toxicData/dataMapper.ts
@@ -245,7 +245,7 @@ export function getChampionPickBanMap(latestMatchList: Match[]): {
     // the
     const matches = latestMatchList.reverse();
     const pickBan: {
-        [id: string]: { pick: number; ban: number; matchNo: number }[];
+        [id: string]: { pick: number; ban: number }[];
     } = {};
 
     // initialize all champion pick bans to 0%
@@ -272,7 +272,6 @@ export function getChampionPickBanMap(latestMatchList: Match[]): {
                     (((latestPickBanData.ban / 100) * (matchNo - 1)) /
                         matchNo) *
                     100,
-                matchNo,
             });
         }
 
@@ -291,7 +290,6 @@ export function getChampionPickBanMap(latestMatchList: Match[]): {
                     (((latestPickBanData.ban / 100) * (matchNo - 1)) /
                         matchNo) *
                     100,
-                matchNo,
             });
         }
 
@@ -313,7 +311,6 @@ export function getChampionPickBanMap(latestMatchList: Match[]): {
                         (((latestPickBanData.ban / 100) * (matchNo - 1) + 1) /
                             matchNo) *
                         100,
-                    matchNo,
                 });
             }
         }
@@ -336,7 +333,6 @@ export function getChampionPickBanMap(latestMatchList: Match[]): {
                         (((latestPickBanData.ban / 100) * (matchNo - 1) + 1) /
                             matchNo) *
                         100,
-                    matchNo,
                 });
             }
         }
@@ -358,7 +354,6 @@ export function getChampionPickBanMap(latestMatchList: Match[]): {
                                 (matchNo - 1)) /
                                 matchNo) *
                             100,
-                        matchNo,
                     });
                 }
             }

--- a/src/types/domain/Champion.ts
+++ b/src/types/domain/Champion.ts
@@ -6,4 +6,5 @@ export type Champion = {
     totalGames: number;
     banPercentage?: number;
     pickPercentage?: number;
+    pickBanHistory?: { pick: number; ban: number }[];
 };


### PR DESCRIPTION
Go to the champion screen, and there will be a new "pick & ban rate" tab that let's you see the champion's data over time