### PR TITLE
Do not use season data for champion win rates on slideshow

### DIFF
--- a/src/admin/Slideshow.tsx
+++ b/src/admin/Slideshow.tsx
@@ -125,7 +125,8 @@ export const Slideshow = React.memo(function Slideshow({
     const playersResponse = ToxicDataService.usePlayers(SEASON_NUMBER);
     const players = playersResponse.data ?? [];
 
-    const championsResponse = ToxicDataService.useChampions(SEASON_NUMBER);
+    // do not limit champion win rate data to a single season (there simply aren't enough games)
+    const championsResponse = ToxicDataService.useChampions();
     const champions = Array.from(Object.values(championsResponse.data ?? {}));
 
     const [slideNo, setSlideNo] = useState(0);
@@ -154,8 +155,7 @@ export const Slideshow = React.memo(function Slideshow({
     // sort the champions by win rate
     const sortedChampions = champions
         ? champions
-              // ignore the placements filter
-              //.filter((value) => value.totalGames >= 10)
+              .filter((value) => value.totalGames >= 10)
               .sort((a, b) => b.winPercentage - a.winPercentage)
         : [];
 

--- a/src/admin/slideshow/PlayerCard.tsx
+++ b/src/admin/slideshow/PlayerCard.tsx
@@ -185,7 +185,7 @@ export const PlayerCard = (props: { player: Player }) => {
                             fontFamily: 'bahnschrift, sans-serif',
                         }}
                     >
-                        MMR
+                        SPR
                     </h1>
                     <h1 style={mmrTextStyle}>
                         {Math.round(props.player.glicko ?? 0)}


### PR DESCRIPTION
The champion win rates screen constantly shows 100% win rate because there are a lot of champions that are only played once during the season. Reverting this to all time champ win rates.

Fixing an issue where "MMR" is displayed when it the label should be "SPR"