### PR TITLE
Add support for milio

### DIFF
--- a/src/data/championClasses.ts
+++ b/src/data/championClasses.ts
@@ -220,4 +220,5 @@ export const ChampionClassMap: { [id: string]: ChampionClass[] } = {
     Shen: [ChampionClass.Warden],
     'Tahm Kench': [ChampionClass.Warden],
     "K'Sante": [ChampionClass.Warden, ChampionClass.Skirmishers],
+    Milio: [ChampionClass.Enchanter],
 };


### PR DESCRIPTION
Adds milio into the champion class mapping. we need to fix this bug for a more long term solution than constantly patching on a per champion basis. 